### PR TITLE
[fix]: 로그아웃 리스트로 개념 변경

### DIFF
--- a/src/main/java/com/example/backend/common/error/code/JwtExceptionCode.java
+++ b/src/main/java/com/example/backend/common/error/code/JwtExceptionCode.java
@@ -14,7 +14,8 @@ public enum JwtExceptionCode implements ExceptionCode {
   JSON_PROCESSING_ERROR(500, "JSON 처리 중 에러 발생하였습니다."),
   MISMATCHED_USER_AGENT(402, "유저의 기기 정보가 일치하지 않습니다."),
   TOKEN_NOT_FOUND_IN_REDIS(402, "레디스에 해당하는 토큰이 없습니다."),
-  TYPE_MISMATCH(500, "레디스에서 타입과 일치하지 않습니다.");
+  TYPE_MISMATCH(500, "레디스에서 타입과 일치하지 않습니다."),
+  REQUIRED_LOGOUT(402,"로그아웃해야하는 유저입니다,");
 
   @Getter
   private int status;


### PR DESCRIPTION
[fix]: 로그아웃 리스트로 개념 변경

<body>
RedisConfig에 있는 redisTemplateForUpdateEmp를 이용해서  사원의 부서이동, 삭제시에  empId(String) : “아무값” (null만아니면됨) 저장하기  필터에서 해당 레디스DB조회에서 로그아웃 시킬수 있도록  => JWTFILTER에서 402 에러응답 반환 처리중  public Authentication getAuthentication(String token,  HttpServletRequest request) {
    Claims claims = parseToken(token); //토큰이 해독되면
    Long tokenEmpId = ((Number) claims.get("empId")).longValue();
    if (isUserRequiredToLogout(tokenEmpId)) { // 유저가 업데이트된적이 없으면 엑세스토큰이 키값으로 되어있는 레디스에서 가져오기
      throw new BusinessLogicException(JwtExceptionCode.REQUIRED_LOGOUT);
    }
    Map<String, Object> userInfoMap = getUserInfoFromRedis(token, request);
//    validateIncomingRequest(request, userInfoMap);
    Long userId = ((Number) userInfoMap.get("userId")).longValue();
    Long empId = ((Number) userInfoMap.get("empId")).longValue();
    UserDetails userDetails = userDetailsService.loadUserByUserIdAndEmpId(userId, empId);
    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
  }
  private boolean isUserRequiredToLogout(Long empId) {
    try{
      String userInfoJson = redisTemplateForUpdateEmp.opsForValue().get(String.valueOf(empId));
      if (userInfoJson == null) { //값잉 없는거니까 accessToken에서 갖고오게하기
        return true;
      }
      return false;
    } catch (RedisException e) {
      throw new BusinessLogicException(JwtExceptionCode.NO_REDIS_CONNECTION);
    }
  }

<footer>